### PR TITLE
Wymuszenie minimalnych wersji pakietów i wsparcie Pythona 3.8+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,12 @@ requires-python = ">=3.8"
 license = {text = "MIT"}
 authors = [{name = "John Matherly", email = "jmath@shodan.io"}]
 dependencies = [
-    "click",
-    "colorama",
-    "requests>=2.2.1",
-    "XlsxWriter",
-    "tldextract",
+    "click>=8.1.7",
+    "click-plugins>=1.1.1",
+    "colorama>=0.4.6",
+    "requests>=2.31.0",
+    "XlsxWriter>=3.1.9",
+    "tldextract>=5.1.2",
     "httpx",
     "uvloop; platform_system != 'Windows'",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-click
-colorama
-requests>=2.2.1
-XlsxWriter
-tldextract
+click>=8.1.7
+click-plugins>=1.1.1
+colorama>=0.4.6
+requests>=2.31.0
+XlsxWriter>=3.1.9
+tldextract>=5.1.2
 httpx
 uvloop; platform_system != 'Windows'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup
+
+setup(
+    name="shodan",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    python_requires=">=3.8",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+    ],
+)


### PR DESCRIPTION
## Podsumowanie
- określono stabilne wersje minimalne zależności
- dodano `setup.py` z wymaganiem `python_requires>=3.8` i klasyfikatorami Pythona 3.8–3.13
- zaktualizowano interpreter do Pythona 3.12.10

## Testy
- `safety check --full-report`
- `pip-audit`
- `pytest` *(niepowodzenie: brak pliku SHODAN-API-KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79f605388330b791e66bff482022