### PR TITLE
Dodaj konfiguracje pre-commit i narzędzia bezpieczeństwa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: ["-q", "-r", "."]
+  - repo: https://github.com/returntocorp/semgrep
+    rev: v1.133.0
+    hooks:
+      - id: semgrep
+  - repo: local
+    hooks:
+      - id: safety
+        name: safety
+        entry: python -m safety check --full-report --file requirements.txt
+        language: system
+        pass_filenames: false
+      - id: trufflehog
+        name: trufflehog
+        entry: /root/.pyenv/versions/3.12.10/bin/trufflehog --json .
+        language: system
+        pass_filenames: false
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+  - repo: https://github.com/GitGuardian/ggshield
+    rev: v1.42.0
+    hooks:
+      - id: ggshield

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,164 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "docs/examples/basic-search.rst": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/examples/basic-search.rst",
+        "hashed_secret": "1e3667aaaaa887721550cf5cc8a0c5c5760810ed",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "docs/examples/cert-stream.rst": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/examples/cert-stream.rst",
+        "hashed_secret": "9a7eba934a997087257c7f3907d5ae5d7956928a",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "docs/examples/query-summary.rst": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/examples/query-summary.rst",
+        "hashed_secret": "9a7eba934a997087257c7f3907d5ae5d7956928a",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "docs/tutorial.rst": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/tutorial.rst",
+        "hashed_secret": "512f73bfc882aa6a525c9ff007e64d28d63d2226",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ]
+  },
+  "generated_at": "2025-08-25T15:00:33Z"
+}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,37 @@
+Wkład w rozwój
+==============
+
+Instalacja środowiska
+---------------------
+
+1. Zainstaluj wymagania:
+
+   .. code-block:: bash
+
+      python -m pip install -r requirements.txt
+
+2. Zainstaluj skrypty pre-commit:
+
+   .. code-block:: bash
+
+      pre-commit install
+
+Sprawdzanie zmian
+-----------------
+
+Przed wysłaniem poprawek uruchom wszystkie testy statyczne i skanery bezpieczeństwa:
+
+.. code-block:: bash
+
+   pre-commit run --all-files
+
+Wytyczne dotyczące commitów
+---------------------------
+
+Do tworzenia wiadomości commit używaj narzędzia Commitizen zgodnego ze standardem Conventional Commits:
+
+.. code-block:: bash
+
+   cz commit
+
+Powyższe polecenie poprowadzi Cię przez proces tworzenia prawidłowej wiadomości commit i automatycznie zweryfikuje format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,8 @@ local_scheme = "no-local-version"
 
 [tool.setuptools.packages.find]
 include = ["shodan", "shodan.*"]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+tag_format = "v$version"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,12 @@ XlsxWriter
 tldextract
 httpx
 uvloop; platform_system != 'Windows'
+# Narzędzia deweloperskie
+pre-commit==4.3.0
+commitizen==4.8.3
+bandit==1.8.6
+semgrep==1.133.0
+safety==3.6.0
+detect-secrets==1.5.0
+trufflehog==2.2.1
+ggshield==1.42.0


### PR DESCRIPTION
## Podsumowanie
- dodano konfigurację pre-commit z bandit, semgrep, safety, detect-secrets, trufflehog i ggshield
- wprowadzono sekcję commitizen i wymagania na narzędzia
- uzupełniono dokumentację wkładu dla deweloperów

## Testowanie
- `GG_OFFLINE_MODE=true python -m pre_commit run --all-files` (ggshield wymaga klucza API, trufflehog zgłosił błąd)


------
https://chatgpt.com/codex/tasks/task_e_68ac79f6e968833092c8ede38f0424e9